### PR TITLE
Added MedNeXT

### DIFF
--- a/models/backbones/mednext.py
+++ b/models/backbones/mednext.py
@@ -1,0 +1,205 @@
+import torch
+import torch.nn as nn
+
+from .mednext_blocks import *
+
+class MedNeXt(nn.Module):
+    """
+    MedNeXt model class.
+
+    Args:
+        init_filters (int): Number of initial filters.
+        in_channels (int): Number of input channels.
+        n_classes (int): Number of output classes.
+        enc_exp_r (int, optional): Expansion ratio for encoder blocks. Defaults to 2.
+        dec_expr_r (int, optional): Expansion ratio for decoder blocks. Defaults to 2.
+        bottlenec_exp_r (int, optional): Expansion ratio for bottleneck blocks. Defaults to 2.
+        kernel_size (int, optional): Kernel size for convolutions. Defaults to 7.
+        deep_supervision (bool, optional): Whether to use deep supervision. Defaults to False.
+        do_res (bool, optional): Whether to use residual connections. Defaults to False.
+        do_res_up_down (bool, optional): Whether to use residual connections in up and down blocks. Defaults to False.
+        enc_blocks (list, optional): Number of blocks in each encoder stage. Defaults to [2, 2, 2, 2].
+        bottleneck_blocks (list, optional): Number of blocks in bottleneck stage. Defaults to 2.
+        dec_blocks (list, optional): Number of blocks in each decoder stage. Defaults to [2, 2, 2, 2].
+        norm_type (str, optional): Type of normalization layer. Defaults to 'group'.
+        dim (str, optional): Dimension of the model ('2d' or '3d'). Defaults to '3d'.
+        grn (bool, optional): Whether to use Global Response Normalization (GRN). Defaults to False.
+    """
+    def __init__(self, 
+        init_filters: int, 
+        in_channels: int,
+        n_classes: int, 
+        enc_exp_r: int = 2,
+        dec_expr_r: int = 2,
+        bottlenec_exp_r: int = 2,
+        kernel_size: int = 7,
+        deep_supervision: bool = False,
+        do_res: bool = False,
+        do_res_up_down: bool = False,
+        enc_blocks: list = [2, 2, 2, 2],  
+        bottleneck_blocks: list = 2,
+        dec_blocks: list = [2, 2, 2, 2],
+        norm_type = 'group',
+        dim = '3d',
+        grn = False
+    ):
+        """
+        Initialize the MedNeXt model.
+
+        This method sets up the architecture of the model, including:
+        - Stem convolution
+        - Encoder stages and downsampling blocks
+        - Bottleneck blocks
+        - Decoder stages and upsampling blocks
+        - Output blocks for deep supervision (if enabled)
+        """
+        super().__init__()
+
+        self.do_ds = deep_supervision
+        assert dim in ['2d', '3d'], "dim must be '2d' or '3d'"
+        enc_kernel_size = dec_kernel_size = kernel_size
+
+        if isinstance(enc_exp_r, int):
+            enc_exp_r = [enc_exp_r] * len(enc_blocks)
+
+        if isinstance(dec_expr_r, int):
+            dec_expr_r = [dec_expr_r] * len(dec_blocks)
+
+        conv = nn.Conv2d if dim == '2d' else nn.Conv3d
+            
+        self.stem = conv(in_channels, init_filters, kernel_size=1)
+        
+        enc_stages = []
+        down_blocks = []
+
+        for i, num_blocks in enumerate(enc_blocks):
+            enc_stages.append(nn.Sequential(*[
+                MedNeXtBlock(
+                    in_channels=init_filters * (2 ** i),
+                    out_channels=init_filters * (2 ** i),
+                    exp_r=enc_exp_r[i],
+                    kernel_size=enc_kernel_size,
+                    do_res=do_res,
+                    norm_type=norm_type,
+                    dim=dim,
+                    grn=grn
+                ) 
+                for _ in range(num_blocks)]
+            ))
+            
+            down_blocks.append(MedNeXtDownBlock(
+                in_channels=init_filters * (2 ** i),
+                out_channels=init_filters * (2 ** (i + 1)),
+                exp_r=enc_exp_r[i],
+                kernel_size=enc_kernel_size,
+                do_res=do_res_up_down,
+                norm_type=norm_type,
+                dim=dim
+            ))
+    
+        self.enc_stages = nn.ModuleList(enc_stages)
+        self.down_blocks = nn.ModuleList(down_blocks)
+
+        self.bottleneck = nn.Sequential(*[
+            MedNeXtBlock(
+                in_channels=init_filters * (2 ** len(enc_blocks)),
+                out_channels=init_filters * (2 ** len(enc_blocks)),
+                exp_r=bottlenec_exp_r,
+                kernel_size=dec_kernel_size,
+                do_res=do_res,
+                norm_type=norm_type,
+                dim=dim,
+                grn=grn
+            )
+            for _ in range(bottleneck_blocks)]
+        )
+        
+        up_blocks = []
+        dec_stages = []
+        for i, num_blocks in enumerate(dec_blocks):
+            up_blocks.append(MedNeXtUpBlock(
+                in_channels=init_filters * (2 ** (len(dec_blocks) - i)),
+                out_channels=init_filters * (2 ** (len(dec_blocks) - i - 1)),
+                exp_r=dec_expr_r[i],
+                kernel_size=dec_kernel_size,
+                do_res=do_res_up_down,
+                norm_type=norm_type,
+                dim=dim,
+                grn=grn
+            ))
+            
+            dec_stages.append(nn.Sequential(*[
+                MedNeXtBlock(
+                    in_channels=init_filters * (2 ** (len(dec_blocks) - i - 1)),
+                    out_channels=init_filters * (2 ** (len(dec_blocks) - i - 1)),
+                    exp_r=dec_expr_r[i],
+                    kernel_size=dec_kernel_size,
+                    do_res=do_res,
+                    norm_type=norm_type,
+                    dim=dim,
+                    grn=grn
+                )
+                for _ in range(num_blocks)]
+            ))
+            
+        self.up_blocks = nn.ModuleList(up_blocks)
+        self.dec_stages = nn.ModuleList(dec_stages)
+
+        self.out_0 = OutBlock(in_channels=init_filters, n_classes=n_classes, dim=dim)
+
+        if deep_supervision:
+            self.out_blocks = nn.ModuleList([
+                OutBlock(in_channels=init_filters * (2 ** i), n_classes=n_classes, dim=dim) 
+                for i in range(1, len(enc_blocks))
+            ])
+
+    def forward(self, x):
+        """
+        Forward pass of the MedNeXt model.
+
+        This method performs the forward pass through the model, including:
+        - Stem convolution
+        - Encoder stages and downsampling
+        - Bottleneck blocks
+        - Decoder stages and upsampling with skip connections
+        - Output blocks for deep supervision (if enabled)
+
+        Args:
+            x (torch.Tensor): Input tensor.
+
+        Returns:
+            torch.Tensor or list: Output tensor(s).
+        """
+        # Apply stem convolution
+        x = self.stem(x)
+        
+        # Encoder forward pass
+        enc_outputs = []
+        for enc_stage, down_block in zip(self.enc_stages, self.down_blocks):
+            x = enc_stage(x)
+            enc_outputs.append(x)
+            x = down_block(x)
+        
+        # Bottleneck forward pass
+        x = self.bottleneck(x)
+        
+        # Initialize deep supervision outputs if enabled
+        if self.do_ds:
+            ds_outputs = [self.out_blocks[-1](x)]
+        
+        # Decoder forward pass with skip connections
+        for i, (up_block, dec_stage) in enumerate(zip(self.up_blocks, self.dec_stages)):
+            x = up_block(x)
+            x = x + enc_outputs[-(i + 1)]
+            x = dec_stage(x)
+            if self.do_ds:
+                ds_outputs.append(self.out_blocks[-(i + 1)](x))
+        
+        # Final output block
+        x = self.out_0(x)
+        
+        # Return output(s)
+        if self.do_ds:
+            return [x] + list(reversed(ds_outputs))
+        else:
+            return x

--- a/models/backbones/mednext.py
+++ b/models/backbones/mednext.py
@@ -151,7 +151,7 @@ class MedNeXt(nn.Module):
         if deep_supervision:
             out_blocks = [
                 OutBlock(in_channels=init_filters * (2 ** i), n_classes=out_channels, dim=spatial_dims) 
-                for i in range(1, len(blocks_up))
+                for i in range(1, len(blocks_up) + 1)
             ]
 
             out_blocks.reverse()
@@ -207,8 +207,6 @@ class MedNeXt(nn.Module):
         
         # Return output(s)
         if self.do_ds:
-            print(len(ds_outputs))
-
-            return [x] + list(reversed(ds_outputs))
+            return (x, *ds_outputs[::-1])
         else:
             return x

--- a/models/backbones/mednext_blocks.py
+++ b/models/backbones/mednext_blocks.py
@@ -1,0 +1,245 @@
+"""
+Taken from: https://github.com/MIC-DKFZ/MedNeXt
+
+
+"""
+
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+
+
+class MedNeXtBlock(nn.Module):
+
+    def __init__(self, 
+                in_channels:int, 
+                out_channels:int, 
+                exp_r:int=4, 
+                kernel_size:int=7, 
+                do_res:int=True,
+                norm_type:str = 'group',
+                n_groups:int or None = None,
+                dim = '3d',
+                grn = False
+                ):
+
+        super().__init__()
+
+        self.do_res = do_res
+
+        assert dim in ['2d', '3d']
+        self.dim = dim
+        if self.dim == '2d':
+            conv = nn.Conv2d
+        elif self.dim == '3d':
+            conv = nn.Conv3d
+            
+        # First convolution layer with DepthWise Convolutions
+        self.conv1 = conv(
+            in_channels = in_channels,
+            out_channels = in_channels,
+            kernel_size = kernel_size,
+            stride = 1,
+            padding = kernel_size//2,
+            groups = in_channels if n_groups is None else n_groups,
+        )
+
+        # Normalization Layer. GroupNorm is used by default.
+        if norm_type=='group':
+            self.norm = nn.GroupNorm(
+                num_groups=in_channels, 
+                num_channels=in_channels
+                )
+        elif norm_type=='layer':
+            self.norm = LayerNorm(
+                normalized_shape=in_channels, 
+                data_format='channels_first'
+                )
+
+        # Second convolution (Expansion) layer with Conv3D 1x1x1
+        self.conv2 = conv(
+            in_channels = in_channels,
+            out_channels = exp_r*in_channels,
+            kernel_size = 1,
+            stride = 1,
+            padding = 0
+        )
+        
+        # GeLU activations
+        self.act = nn.GELU()
+        
+        # Third convolution (Compression) layer with Conv3D 1x1x1
+        self.conv3 = conv(
+            in_channels = exp_r*in_channels,
+            out_channels = out_channels,
+            kernel_size = 1,
+            stride = 1,
+            padding = 0
+        )
+
+        self.grn = grn
+        if grn:
+            if dim == '3d':
+                self.grn_beta = nn.Parameter(torch.zeros(1,exp_r*in_channels,1,1,1), requires_grad=True)
+                self.grn_gamma = nn.Parameter(torch.zeros(1,exp_r*in_channels,1,1,1), requires_grad=True)
+            elif dim == '2d':
+                self.grn_beta = nn.Parameter(torch.zeros(1,exp_r*in_channels,1,1), requires_grad=True)
+                self.grn_gamma = nn.Parameter(torch.zeros(1,exp_r*in_channels,1,1), requires_grad=True)
+
+ 
+    def forward(self, x, dummy_tensor=None):
+        
+        x1 = x
+        x1 = self.conv1(x1)
+        x1 = self.act(self.conv2(self.norm(x1)))
+        if self.grn:
+            # gamma, beta: learnable affine transform parameters
+            # X: input of shape (N,C,H,W,D)
+            if self.dim == '3d':
+                gx = torch.norm(x1, p=2, dim=(-3, -2, -1), keepdim=True)
+            elif self.dim == '2d':
+                gx = torch.norm(x1, p=2, dim=(-2, -1), keepdim=True)
+            nx = gx / (gx.mean(dim=1, keepdim=True)+1e-6)
+            x1 = self.grn_gamma * (x1 * nx) + self.grn_beta + x1
+        x1 = self.conv3(x1)
+        if self.do_res:
+            x1 = x + x1  
+        return x1
+
+
+class MedNeXtDownBlock(MedNeXtBlock):
+
+    def __init__(self, in_channels, out_channels, exp_r=4, kernel_size=7, 
+                do_res=False, norm_type = 'group', dim='3d', grn=False):
+
+        super().__init__(in_channels, out_channels, exp_r, kernel_size, 
+                        do_res = False, norm_type = norm_type, dim=dim,
+                        grn=grn)
+
+        if dim == '2d':
+            conv = nn.Conv2d
+        elif dim == '3d':
+            conv = nn.Conv3d
+        self.resample_do_res = do_res
+        if do_res:
+            self.res_conv = conv(
+                in_channels = in_channels,
+                out_channels = out_channels,
+                kernel_size = 1,
+                stride = 2
+            )
+
+        self.conv1 = conv(
+            in_channels = in_channels,
+            out_channels = in_channels,
+            kernel_size = kernel_size,
+            stride = 2,
+            padding = kernel_size//2,
+            groups = in_channels,
+        )
+
+    def forward(self, x, dummy_tensor=None):
+        
+        x1 = super().forward(x)
+        
+        if self.resample_do_res:
+            res = self.res_conv(x)
+            x1 = x1 + res
+
+        return x1
+
+
+class MedNeXtUpBlock(MedNeXtBlock):
+
+    def __init__(self, in_channels, out_channels, exp_r=4, kernel_size=7, 
+                do_res=False, norm_type = 'group', dim='3d', grn = False):
+        super().__init__(in_channels, out_channels, exp_r, kernel_size,
+                         do_res=False, norm_type = norm_type, dim=dim,
+                         grn=grn)
+
+        self.resample_do_res = do_res
+        
+        self.dim = dim
+        if dim == '2d':
+            conv = nn.ConvTranspose2d
+        elif dim == '3d':
+            conv = nn.ConvTranspose3d
+        if do_res:            
+            self.res_conv = conv(
+                in_channels = in_channels,
+                out_channels = out_channels,
+                kernel_size = 1,
+                stride = 2
+                )
+
+        self.conv1 = conv(
+            in_channels = in_channels,
+            out_channels = in_channels,
+            kernel_size = kernel_size,
+            stride = 2,
+            padding = kernel_size//2,
+            groups = in_channels,
+        )
+
+
+    def forward(self, x, dummy_tensor=None):
+        
+        x1 = super().forward(x)
+        # Asymmetry but necessary to match shape
+        
+        if self.dim == '2d':
+            x1 = torch.nn.functional.pad(x1, (1,0,1,0))
+        elif self.dim == '3d':
+            x1 = torch.nn.functional.pad(x1, (1,0,1,0,1,0))
+        
+        if self.resample_do_res:
+            res = self.res_conv(x)
+            if self.dim == '2d':
+                res = torch.nn.functional.pad(res, (1,0,1,0))
+            elif self.dim == '3d':
+                res = torch.nn.functional.pad(res, (1,0,1,0,1,0))
+            x1 = x1 + res
+
+        return x1
+
+
+class OutBlock(nn.Module):
+
+    def __init__(self, in_channels, n_classes, dim):
+        super().__init__()
+        
+        if dim == '2d':
+            conv = nn.ConvTranspose2d
+        elif dim == '3d':
+            conv = nn.ConvTranspose3d
+        self.conv_out = conv(in_channels, n_classes, kernel_size=1)
+    
+    def forward(self, x, dummy_tensor=None): 
+        return self.conv_out(x)
+
+
+class LayerNorm(nn.Module):
+    """ LayerNorm that supports two data formats: channels_last (default) or channels_first. 
+    The ordering of the dimensions in the inputs. channels_last corresponds to inputs with 
+    shape (batch_size, height, width, channels) while channels_first corresponds to inputs 
+    with shape (batch_size, channels, height, width).
+    """
+    def __init__(self, normalized_shape, eps=1e-5, data_format="channels_last"):
+        super().__init__()
+        self.weight = nn.Parameter(torch.ones(normalized_shape))        # beta
+        self.bias = nn.Parameter(torch.zeros(normalized_shape))         # gamma
+        self.eps = eps
+        self.data_format = data_format
+        if self.data_format not in ["channels_last", "channels_first"]:
+            raise NotImplementedError 
+        self.normalized_shape = (normalized_shape, )
+    
+    def forward(self, x, dummy_tensor=False):
+        if self.data_format == "channels_last":
+            return F.layer_norm(x, self.normalized_shape, self.weight, self.bias, self.eps)
+        elif self.data_format == "channels_first":
+            u = x.mean(1, keepdim=True)
+            s = (x - u).pow(2).mean(1, keepdim=True)
+            x = (x - u) / torch.sqrt(s + self.eps)
+            x = self.weight[:, None, None, None] * x + self.bias[:, None, None, None]
+            return x


### PR DESCRIPTION
Not an improvement from our segresnet. Validated on TS with decoder only and 50 training scans. Val set: 50 images

Tried approaches
1. MedNeXT-L (60M params)
2. MedNexXT with our asymmetric encoder-decoder structure (100M params) 


![MedNeXT comparisons](https://github.com/ibro45/lighter-ct-fm/assets/10467804/4c5670d4-92b1-4d18-bd11-4e2a924150dd)
